### PR TITLE
Enhance tile elevation with deeper shadows

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -27,6 +27,9 @@
   --r-12: 12px;
   --r-16: 16px;
   --shadow-md: 0 8px 20px rgba(0, 0, 0, 0.08);
+  --shadow-tile: 0 18px 34px rgba(74, 57, 36, 0.16), 0 6px 14px rgba(74, 57, 36, 0.12),
+    0 2px 6px rgba(74, 57, 36, 0.08);
+  --tile-highlight: rgba(255, 255, 255, 0.6);
   --safe-top: env(safe-area-inset-top, 0px);
 }
 
@@ -42,4 +45,7 @@
   --card: #333333;
   --border: #444444;
   --shadow-md: 0 8px 20px rgba(0, 0, 0, 0.35);
+  --shadow-tile: 0 22px 40px rgba(0, 0, 0, 0.65), 0 8px 18px rgba(0, 0, 0, 0.45),
+    0 2px 6px rgba(0, 0, 0, 0.35);
+  --tile-highlight: rgba(255, 255, 255, 0.12);
 }

--- a/css/tiles.css
+++ b/css/tiles.css
@@ -15,8 +15,19 @@
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--r-12);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-tile);
   padding: 18px;
+  overflow: hidden;
+}
+
+.dashboard-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(180deg, var(--tile-highlight) 0%, rgba(255, 255, 255, 0) 45%);
+  mix-blend-mode: soft-light;
 }
 
 .dashboard-card:not(.span-2) {
@@ -165,11 +176,23 @@ body.card-dragging {
 }
 
 .stat-card {
+  position: relative;
   background: var(--bg-1);
   border: 1px solid var(--border);
   border-radius: var(--r-12);
   padding: 16px;
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-tile);
+  overflow: hidden;
+}
+
+.stat-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(180deg, var(--tile-highlight) 0%, rgba(255, 255, 255, 0) 50%);
+  mix-blend-mode: soft-light;
 }
 
 .stat-label {


### PR DESCRIPTION
## Summary
- add dedicated tile shadow and highlight variables for light and dark themes
- update dashboard and stat tiles to use richer shadows with subtle top sheen for a raised feel

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d55ad86f20832c93735fbb8c1003ad