### PR TITLE
Fix logout button listener setup

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -49,7 +49,11 @@ const pwaInstallBtn = document.getElementById('pwa-install');
 const menuOpenBtn = document.getElementById('menu-open');
 const menuCloseBtn = document.getElementById('menu-close');
 const logoutBtn = document.getElementById('logout-btn');
-const logoutBtnMain.addEventListener('click', signOut);
+const logoutBtnMain = document.getElementById('logout-btn-main');
+logoutBtn.addEventListener('click', signOut);
+if (logoutBtnMain) {
+  logoutBtnMain.addEventListener('click', signOut);
+}
 const userInfo = document.getElementById('user-info');
 const userName = document.getElementById('user-name');
 const exportBtn = document.getElementById('export-button');


### PR DESCRIPTION
## Summary
- correct the logout button event registration in `main.js`
- ensure both sidebar and main logout buttons invoke the sign-out handler safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d589ccb3c8832cba52614946f0786a