### PR TITLE
Fix logout handler syntax error

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -76,6 +76,8 @@ function signOut(event) {
 
   });
 
+}
+
 
 const userInfo = document.getElementById('user-info');
 const userName = document.getElementById('user-name');


### PR DESCRIPTION
## Summary
- close the logout handler function to restore valid syntax
- ensure the remainder of the main script executes for top bar interactivity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d59950caa0832cb4ec5d2ec4dc5109