### PR TITLE
Add donation messaging to support tile

### DIFF
--- a/css/tiles.css
+++ b/css/tiles.css
@@ -137,6 +137,11 @@ body.card-dragging {
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
 }
 
+.support-illustration {
+  width: 80px;
+  height: auto;
+}
+
 .support-badge {
   display: inline-flex;
   align-items: center;

--- a/js/main.js
+++ b/js/main.js
@@ -1033,7 +1033,12 @@ const setupEventListeners = (tileSystem) => {
 
   // Donation buttons
   if (donateBtn) donateBtn.addEventListener('click', openDonationPage);
-  if (supportCard) supportCard.addEventListener('click', openDonationPage);
+  if (supportCard) {
+    supportCard.addEventListener('click', () => {
+      if (tileSystem.isReorganizeMode()) return;
+      openDonationPage();
+    });
+  }
 
   // Language toggle
   if (langToggle) {

--- a/js/tiles/support.js
+++ b/js/tiles/support.js
@@ -4,11 +4,15 @@ const supportTile = {
   classNames: ['support-card'],
   ariaLabelledBy: 'support-title',
   span: false,
-   template: `
+  template: `
       <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
       <button class="close-btn" aria-label="Finish organizing">&times;</button>
-      <div class="logo-card-inner">
-        <img src="support.png" alt="McFatty's Support logo">
+      <div class="support-card-inner">
+        <span class="support-badge" data-i18n="supportBadge">Keep McFatty’s free</span>
+        <img src="support.png" alt="McFatty's donation jar illustration" class="support-illustration">
+        <h3 id="support-title" data-i18n="supportTitle">Support us</h3>
+        <p class="support-copy" data-i18n="supportCopy">Chip in to cover hosting and keep the tracker open for everyone.</p>
+        <button id="support-button" class="btn btn-primary" type="button" data-i18n="donateBtn">Donate</button>
       </div>
     `
 };


### PR DESCRIPTION
## Summary
- display donation context inside the support dashboard tile including translations and call-to-action button
- style the new illustration and guard against triggering the donation link while reorganizing tiles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d652adf254832c9bf1ae15d3de9db9