### PR TITLE
Revamp dashboard tiles with gradient styling

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -386,7 +386,7 @@
 }
 
 .dashboard-grid.is-reordering .dashboard-card {
-  padding-top: calc(18px + 36px);
+  padding-top: calc(var(--card-padding, 18px) + 36px);
   cursor: grab;
 }
 

--- a/css/tiles.css
+++ b/css/tiles.css
@@ -1,62 +1,488 @@
-.support-card {
-  padding: 0;
+.dashboard-card {
+  --card-padding: clamp(20px, 3vw, 28px);
+  --tile-radius: 26px;
+  --tile-gradient: linear-gradient(135deg, #f3ede0 0%, #ffffff 100%);
+  --tile-text: var(--text-0);
+  --tile-surface: rgba(255, 255, 255, 0.72);
+  --tile-border: rgba(0, 0, 0, 0.08);
+  --tile-shadow: 0 22px 40px rgba(31, 28, 22, 0.16);
+  --table-head-bg: rgba(255, 255, 255, 0.65);
+  --table-row-divider: rgba(0, 0, 0, 0.06);
+  position: relative;
+  padding: var(--card-padding);
+  border-radius: var(--tile-radius);
+  background: var(--tile-gradient);
+  border: none;
+  color: var(--tile-text);
+  box-shadow: var(--tile-shadow);
+  overflow: hidden;
+  isolation: isolate;
 }
 
-.support-card-inner {
+.dashboard-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(140% 120% at 12% -20%, rgba(255, 255, 255, 0.5) 0%, transparent 60%),
+    radial-gradient(120% 140% at 90% 110%, rgba(255, 255, 255, 0.22) 0%, transparent 70%);
+  opacity: 0.9;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  z-index: 0;
+}
+
+.dashboard-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+@media (hover: hover) {
+  .dashboard-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 26px 46px rgba(31, 28, 22, 0.2);
+  }
+}
+
+.dashboard-card h2,
+.dashboard-card h3 {
+  color: inherit;
+  margin: 0;
+  letter-spacing: 0.04em;
+}
+
+.dashboard-card h2 {
+  font-size: clamp(20px, 4vw, 28px);
+  text-transform: uppercase;
+}
+
+.dashboard-card h3 {
+  font-size: clamp(18px, 3.5vw, 22px);
+}
+
+.dashboard-card p,
+.dashboard-card span,
+.dashboard-card label,
+.dashboard-card th,
+.dashboard-card td,
+.dashboard-card strong {
+  color: inherit;
+}
+
+.dashboard-card p {
+  margin: 0;
+  opacity: 0.9;
+  line-height: 1.55;
+}
+
+.dashboard-card p + p {
+  margin-top: 0.75rem;
+}
+
+.dashboard-card .info-text {
+  opacity: 0.8;
+}
+
+.dashboard-card .btn {
+  border-radius: 16px;
+  font-weight: 600;
+  padding-inline: 22px;
+  box-shadow: none;
+}
+
+.dashboard-card .btn-secondary,
+.dashboard-card .icon-btn {
+  background: var(--tile-surface);
+  border: 1px solid var(--tile-border);
+  color: var(--tile-text);
+}
+
+.dashboard-card .btn-secondary:hover,
+.dashboard-card .icon-btn:hover {
+  filter: brightness(1.05);
+}
+
+.dashboard-card .drag-handle,
+.dashboard-card .close-btn {
+  background: var(--tile-surface);
+  border-color: var(--tile-border);
+  color: var(--tile-text);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.08);
+}
+
+.dashboard-card .drag-handle span {
+  background: currentColor;
+  opacity: 0.6;
+}
+
+.dashboard-card .input,
+.dashboard-card select,
+.dashboard-card textarea {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--tile-border);
+  color: var(--tile-text);
+  border-radius: 16px;
+  padding: 14px 16px;
+}
+
+.dashboard-card .input:focus,
+.dashboard-card select:focus,
+.dashboard-card textarea:focus {
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.35);
+}
+
+.dashboard-card .table {
+  width: 100%;
+  border-collapse: collapse;
+  border-radius: 20px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.88);
+  margin-top: var(--sp-12);
+}
+
+.dashboard-card .table thead {
+  background: var(--table-head-bg);
+}
+
+.dashboard-card .table th,
+.dashboard-card .table td {
+  padding: 12px 16px;
+  text-align: left;
+}
+
+.dashboard-card .table th {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.dashboard-card .table tbody tr:not(:last-child) {
+  border-bottom: 1px solid var(--table-row-divider);
+}
+
+.dashboard-card .table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.32);
+}
+
+/* --- Tile themes --------------------------------------------------------- */
+
+.tile--welcome {
+  --tile-gradient: linear-gradient(135deg, #f6c667 0%, #f46861 100%);
+  --tile-text: #fff7ec;
+  --tile-surface: rgba(255, 255, 255, 0.2);
+  --tile-border: rgba(255, 255, 255, 0.32);
+  --table-head-bg: rgba(255, 255, 255, 0.24);
+  --table-row-divider: rgba(255, 255, 255, 0.2);
+}
+
+.tile--welcome #welcome-message {
+  font-size: clamp(24px, 6vw, 36px);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  line-height: 1.12;
+  text-shadow: 0 10px 24px rgba(0, 0, 0, 0.25);
+}
+
+.tile--logo {
+  --tile-gradient: linear-gradient(135deg, #fff0c9 0%, #f7c25d 100%);
+  --tile-text: #3a2200;
+  --tile-surface: rgba(255, 255, 255, 0.65);
+  --tile-border: rgba(255, 190, 90, 0.45);
+  --table-row-divider: rgba(58, 34, 0, 0.08);
+}
+
+.tile--manifesto {
+  --tile-gradient: linear-gradient(135deg, #c13f4c 0%, #f06d4f 100%);
+  --tile-text: #fff7f4;
+  --tile-surface: rgba(255, 255, 255, 0.18);
+  --tile-border: rgba(255, 255, 255, 0.32);
+  --table-head-bg: rgba(255, 255, 255, 0.26);
+  --table-row-divider: rgba(255, 255, 255, 0.2);
+}
+
+.tile--growth {
+  --tile-gradient: linear-gradient(135deg, #1f8a70 0%, #72c4a3 100%);
+  --tile-text: #f4fff7;
+  --tile-surface: rgba(255, 255, 255, 0.18);
+  --tile-border: rgba(255, 255, 255, 0.3);
+  --table-head-bg: rgba(255, 255, 255, 0.28);
+  --table-row-divider: rgba(255, 255, 255, 0.18);
+}
+
+.tile--support {
+  --tile-gradient: linear-gradient(135deg, #0d5f4d 0%, #6bd08c 100%);
+  --tile-text: #f7fff8;
+  --tile-surface: rgba(255, 255, 255, 0.18);
+  --tile-border: rgba(255, 255, 255, 0.3);
+  --table-head-bg: rgba(255, 255, 255, 0.24);
+  --table-row-divider: rgba(255, 255, 255, 0.16);
+}
+
+.tile--stats {
+  --tile-gradient: linear-gradient(135deg, #5a3ffb 0%, #7a9bff 100%);
+  --tile-text: #f7f6ff;
+  --tile-surface: rgba(255, 255, 255, 0.18);
+  --tile-border: rgba(255, 255, 255, 0.28);
+  --table-head-bg: rgba(255, 255, 255, 0.24);
+  --table-row-divider: rgba(255, 255, 255, 0.16);
+}
+
+.tile--quick-add {
+  --tile-gradient: linear-gradient(135deg, #ffe0c2 0%, #fff7df 100%);
+  --tile-text: #3d2410;
+  --tile-surface: rgba(255, 255, 255, 0.85);
+  --tile-border: rgba(255, 184, 110, 0.5);
+  --table-head-bg: rgba(255, 255, 255, 0.8);
+  --table-row-divider: rgba(61, 36, 16, 0.08);
+}
+
+.tile--recent-log {
+  --tile-gradient: linear-gradient(135deg, #4bb3a5 0%, #92e0b5 45%, #f4fbe8 100%);
+  --tile-text: #133327;
+  --tile-surface: rgba(255, 255, 255, 0.7);
+  --tile-border: rgba(19, 51, 39, 0.16);
+  --table-head-bg: rgba(255, 255, 255, 0.85);
+  --table-row-divider: rgba(19, 51, 39, 0.08);
+}
+
+/* --- Logo tiles ---------------------------------------------------------- */
+
+.logo-card .logo-card-inner {
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: var(--sp-12);
+  min-height: 180px;
+  padding: clamp(16px, 3vw, 24px);
+}
+
+.logo-card .logo-card-inner img {
+  width: min(220px, 70%);
+  filter: drop-shadow(0 18px 28px rgba(0, 0, 0, 0.25));
+}
+
+.tile--manifesto .logo-card-inner img {
+  width: min(200px, 65%);
+}
+
+/* --- Support tile -------------------------------------------------------- */
+
+.support-card-inner {
+  display: grid;
+  gap: var(--sp-16);
+  align-items: center;
+  justify-items: center;
   text-align: center;
-  width: 100%;
-  height: 100%;
-  padding: var(--sp-24);
-  border-radius: calc(var(--r-12) - 2px);
-  background: radial-gradient(120% 120% at 50% 0%, rgba(255, 218, 111, 0.35) 0%, rgba(255, 218, 111, 0) 70%), var(--bg-1);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+  padding: clamp(20px, 4vw, 28px);
+  border-radius: calc(var(--tile-radius) - 6px);
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--tile-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
 [data-theme="light"] .support-card-inner {
-  background: radial-gradient(120% 120% at 50% 0%, rgba(255, 207, 98, 0.45) 0%, rgba(255, 207, 98, 0) 70%), var(--bg-0);
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+  background: rgba(255, 255, 255, 0.2);
 }
 
-/* Responsive illustration size merging both branches */
 .support-illustration {
-  width: clamp(80px, 25vw, 320px);
-  max-width: 100%;
+  width: clamp(120px, 28vw, 220px);
   height: auto;
 }
 
-/* Badge kept from main */
 .support-badge {
   display: inline-flex;
   align-items: center;
   gap: var(--sp-8);
-  padding: 6px 12px;
+  padding: 6px 14px;
   border-radius: 999px;
   font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-weight: 700;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--text-1);
-  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.24);
 }
 
 [data-theme="light"] .support-badge {
-  color: var(--text-2);
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(255, 255, 255, 0.3);
+  border-color: rgba(255, 255, 255, 0.4);
 }
 
-.support-copy {
-  font-size: 14px;
-  color: var(--text-1);
-  line-height: 1.5;
+.support-card .btn-primary {
+  background: rgba(255, 255, 255, 0.92);
+  border-color: transparent;
+  color: #0d5f4d;
 }
 
-.support-card .btn {
-  width: 100%;
-  justify-content: center;
+.support-card .btn-primary:hover {
+  filter: brightness(1.05);
 }
 
+/* --- Quick add tile ------------------------------------------------------ */
+
+.tile--quick-add .quick-add-subtext {
+  max-width: 520px;
+  margin-bottom: var(--sp-12);
+}
+
+.quick-add-body {
+  display: grid;
+  gap: var(--sp-16);
+}
+
+@media (min-width: 720px) {
+  .quick-add-body {
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.quick-add-actions {
+  display: grid;
+  gap: var(--sp-12);
+  align-content: start;
+}
+
+.quick-add-actions label {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-8);
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: var(--tile-surface);
+  border: 1px solid var(--tile-border);
+}
+
+.quick-add-actions .checkbox {
+  width: 20px;
+  height: 20px;
+  accent-color: var(--primary);
+}
+
+.quick-add-actions button {
+  justify-self: start;
+}
+
+/* --- Stats tile ---------------------------------------------------------- */
+
+.tile--stats .quick-stats-grid {
+  display: grid;
+  gap: var(--sp-16);
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.tile--stats .stat-card {
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 18px;
+  padding: 16px;
+  border: 1px solid var(--tile-border);
+  display: grid;
+  gap: 8px;
+}
+
+.tile--stats .stat-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.tile--stats .stat-value {
+  font-size: clamp(26px, 5vw, 38px);
+  font-weight: 700;
+}
+
+.tile--stats .stat-subtext {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+/* --- Recent log tile ----------------------------------------------------- */
+
+.tile--recent-log .section-head {
+  align-items: flex-start;
+  gap: var(--sp-12);
+}
+
+.tile--recent-log #export-button {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(19, 51, 39, 0.1);
+  color: var(--tile-text);
+}
+
+.tile--recent-log #export-button:hover {
+  filter: brightness(1.05);
+}
+
+.tile--recent-log .log-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-12);
+  align-items: center;
+}
+
+.tile--recent-log .log-search {
+  flex: 1 1 220px;
+}
+
+.tile--recent-log .log-search .input {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--tile-border);
+}
+
+.tile--recent-log .filter-group {
+  display: inline-flex;
+  gap: var(--sp-8);
+  padding: 6px;
+  border-radius: 999px;
+  background: var(--tile-surface);
+  border: 1px solid var(--tile-border);
+}
+
+.tile--recent-log .filter-btn {
+  border: none;
+  background: none;
+  color: inherit;
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 999px;
+}
+
+.tile--recent-log .filter-btn.is-active {
+  background: rgba(255, 255, 255, 0.55);
+  color: var(--tile-text);
+}
+
+.tile--recent-log .info-text {
+  background: rgba(255, 255, 255, 0.72);
+  border-radius: 14px;
+  padding: 12px 16px;
+}
+
+@media (max-width: 600px) {
+  .dashboard-card {
+    --card-padding: 20px;
+    border-radius: 22px;
+  }
+
+  .tile--welcome #welcome-message {
+    font-size: clamp(22px, 8vw, 30px);
+  }
+
+  .tile--recent-log .log-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .tile--recent-log .filter-group {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .tile--recent-log .filter-btn {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+}

--- a/js/tiles/growth.js
+++ b/js/tiles/growth.js
@@ -1,7 +1,7 @@
 const growthTile = {
   id: 'growth',
   elementId: 'growth-section',
-  classNames: [],
+  classNames: ['tile--growth'],
   ariaLabelledBy: 'growth-title',
   span: false,
   template: `

--- a/js/tiles/logo.js
+++ b/js/tiles/logo.js
@@ -1,7 +1,7 @@
 const logoTile = {
   id: 'logo',
   elementId: 'logo-card',
-  classNames: ['logo-card'],
+  classNames: ['logo-card', 'tile--logo'],
   ariaLabel: "McFatty's logo",
   span: false,
   template: `

--- a/js/tiles/manifesto.js
+++ b/js/tiles/manifesto.js
@@ -1,7 +1,7 @@
 const manifestoTile = {
   id: 'manifesto',
   elementId: 'manifesto-card',
-  classNames: ['logo-card'],
+  classNames: ['logo-card', 'tile--manifesto'],
   ariaLabel: "McFatty's Manifesto",
   span: false,
   template: `

--- a/js/tiles/quick-add.js
+++ b/js/tiles/quick-add.js
@@ -1,7 +1,7 @@
 const quickAddTile = {
   id: 'quick-add',
   elementId: 'add-item-section',
-  classNames: ['span-2'],
+  classNames: ['span-2', 'tile--quick-add'],
   ariaLabelledBy: 'addItem',
   span: true,
   template: `

--- a/js/tiles/recent-log.js
+++ b/js/tiles/recent-log.js
@@ -1,7 +1,7 @@
 const recentLogTile = {
   id: 'recent-log',
   elementId: 'log-section',
-  classNames: ['span-2'],
+  classNames: ['span-2', 'tile--recent-log'],
   ariaLabelledBy: 'recentLog',
   span: true,
   template: `

--- a/js/tiles/stats.js
+++ b/js/tiles/stats.js
@@ -1,7 +1,7 @@
 const statsTile = {
   id: 'stats',
   elementId: 'stats-section',
-  classNames: ['span-2'],
+  classNames: ['span-2', 'tile--stats'],
   ariaLabelledBy: 'quick-stats-title',
   span: true,
   template: `

--- a/js/tiles/support.js
+++ b/js/tiles/support.js
@@ -1,7 +1,7 @@
 const supportTile = {
   id: 'support',
   elementId: 'support-card',
-  classNames: ['support-card'],
+  classNames: ['support-card', 'tile--support'],
   span: false,
   template: `
     <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>

--- a/js/tiles/welcome.js
+++ b/js/tiles/welcome.js
@@ -1,7 +1,7 @@
 const welcomeTile = {
   id: 'welcome',
   elementId: 'welcome-section',
-  classNames: [],
+  classNames: ['tile--welcome'],
   ariaLabelledBy: 'welcome-message',
   span: false,
   template: `


### PR DESCRIPTION
## Summary
- restyle dashboard cards with gradient backgrounds, typography, and glassmorphism-inspired surfaces
- add per-tile theme classes to each tile definition for consistent styling
- refine quick add, stats, and recent log layouts to fit the refreshed tile design

## Testing
- Viewed index.html via `python3 -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68d6e867a928832cbee597470d51537b