### PR TITLE
Fix initialization of context and intention UI references

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -134,12 +134,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   emptyState = document.getElementById('empty-state');
   installBanner = document.getElementById('install-banner');
 
-  const contextFollowup = document.getElementById('context-followup');
-  const contextFeelingButtons = Array.from(document.querySelectorAll('.context-feeling'));
-  const contextSettingInput = document.getElementById('context-setting');
-  const contextSaveBtn = document.getElementById('save-context');
-  const contextSkipBtn = document.getElementById('skip-context');
-  const contextStatus = document.getElementById('context-status');
+  contextFollowup = document.getElementById('context-followup');
+  contextFeelingButtons = Array.from(document.querySelectorAll('.context-feeling'));
+  contextSettingInput = document.getElementById('context-setting');
+  contextSaveBtn = document.getElementById('save-context');
+  contextSkipBtn = document.getElementById('skip-context');
+  contextStatus = document.getElementById('context-status');
 
   contextFeature?.assignElements({
     followup: contextFollowup,
@@ -227,24 +227,24 @@ document.addEventListener('DOMContentLoaded', async () => {
   authPassword = document.getElementById('auth-password');
   authUsername = document.getElementById('auth-username');
   authRePassword = document.getElementById('auth-re-password');
-  const intentionFormEl = document.getElementById('intention-form');
-  const intentionTextareaEl = document.getElementById('intention-text');
-  const intentionSaveBtnEl = document.getElementById('intention-save');
-  const intentionDisplayEl = document.getElementById('intention-display');
-  const intentionCurrentEl = intentionDisplayEl ? intentionDisplayEl.querySelector('.intention-current') : null;
-  const intentionDateEl = intentionDisplayEl ? intentionDisplayEl.querySelector('.intention-date') : null;
-  const intentionEditBtnEl = document.getElementById('intention-edit');
-  const intentionStatusEl = document.getElementById('intention-status');
+  intentionForm = document.getElementById('intention-form');
+  intentionTextarea = document.getElementById('intention-text');
+  intentionSaveBtn = document.getElementById('intention-save');
+  intentionDisplay = document.getElementById('intention-display');
+  intentionCurrent = intentionDisplay ? intentionDisplay.querySelector('.intention-current') : null;
+  intentionDate = intentionDisplay ? intentionDisplay.querySelector('.intention-date') : null;
+  intentionEditBtn = document.getElementById('intention-edit');
+  intentionStatus = document.getElementById('intention-status');
 
   intentionFeature?.assignElements({
-    form: intentionFormEl,
-    textarea: intentionTextareaEl,
-    saveBtn: intentionSaveBtnEl,
-    display: intentionDisplayEl,
-    current: intentionCurrentEl,
-    date: intentionDateEl,
-    editBtn: intentionEditBtnEl,
-    status: intentionStatusEl
+    form: intentionForm,
+    textarea: intentionTextarea,
+    saveBtn: intentionSaveBtn,
+    display: intentionDisplay,
+    current: intentionCurrent,
+    date: intentionDate,
+    editBtn: intentionEditBtn,
+    status: intentionStatus
   });
 
   // Initialize tile system after elements are available


### PR DESCRIPTION
## Summary
- assign context reflection elements to shared module scope so later helpers can use them
- expose intention form elements at module scope to keep feature hooks working after load

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8c7973e0c832cb71faa6dfdb6daf9